### PR TITLE
Remove local exec, use cryptographic random password generator

### DIFF
--- a/htpasswd.sh
+++ b/htpasswd.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-eval "$(jq -r '@sh "PASS=\(.pass)"')"
-printf '{"file":"%s"}' `htpasswd -nb admin $PASS`

--- a/main.tf
+++ b/main.tf
@@ -1,13 +1,6 @@
-resource "random_string" "password" {
+resource "random_password" "password" {
   length  = 48
-  special = true
-}
-
-data "external" "htpasswd" {
-  program = ["/bin/sh", "${path.module}/htpasswd.sh"]
-  query = {
-    pass = random_string.password.result
-  }
+  special = false
 }
 
 resource "kubernetes_secret" "basic-auth" {
@@ -16,7 +9,7 @@ resource "kubernetes_secret" "basic-auth" {
     namespace = var.namespace
   }
   data = {
-    auth = data.external.htpasswd.result.file
+    auth = "${var.username}:${bcrypt(random_password.password.result, 10)}"
   }
   lifecycle {
     ignore_changes = [data]

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 output "password" {
-  description = "The htpasswd-encoded basic auth password."
-  value       = random_string.password.result
+  description = "The randomly-generated basic auth password."
+  value       = random_password.password.result
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -8,3 +8,9 @@ variable "name" {
   description = "Name of the basic auth secret to create."
 }
 
+variable "username" {
+  type        = string
+  default     = "admin"
+  description = "Username to use for basic auth"
+}
+


### PR DESCRIPTION
Changes:

* Generate the htpasswd auth secret directly using the bcrypt function
* Use random_password instead of random_string for better randomness + not displaying the password in terraform CLI output
* Allows specifying other usernames than the default one