### PR TITLE
Create providers.tf, defining kubernetes provider

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+      version = "2.5.0"
+    }
+  }
+}


### PR DESCRIPTION
This enables this module to be used in a context that has multiple providers to be used, each with an alias, and then a specific provider to be passed into the module to be used for a Kubernetes connection.